### PR TITLE
Docs: Fix Broken URLs Across Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ When you're creating a pull request, please:
 
 ## Code of Conduct
 
-By participating in this project, you're expected to uphold our [Code of Conduct](https://github.com/Pepperbot-co/pepperbot/CODE_OF_CONDUCT.md). Please report unacceptable behavior to `coc@pepperbot.co`.
+By participating in this project, you're expected to uphold our [Code of Conduct](https://github.com/PepperBot-co/pepperbot/blob/main/CODE_OF_CONDUCT.md). Please report unacceptable behavior to `coc@pepperbot.co`.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For more specific information about Pepperbot, visit the [Pepperbot Documentatio
 
 ## Contributing
 
-As an open-source project, we encourage community involvement and contributions. Check out our [Contributor Guidelines](https://github.com/Pepperbot-co/pepperbot/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/Pepperbot-co/pepperbot/CODE_OF_CONDUCT.md).
+As an open-source project, we encourage community involvement and contributions. Check out our [Contributor Guidelines](https://github.com/PepperBot-co/pepperbot/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/PepperBot-co/pepperbot/blob/main/CODE_OF_CONDUCT.md).
 
 ## Deployment
 
@@ -40,7 +40,7 @@ Pepperbot can be deployed in various environments. Follow our deployment guides 
 
 ## License
 
-Pepperbot is [MIT licensed](https://github.com/Pepperbot-co/pepperbot/LICENSE.md).
+Pepperbot is [MIT licensed](https://github.com/PepperBot-co/pepperbot/blob/main/LICENSE.md).
 
 ## Acknowledgements
 


### PR DESCRIPTION
### This Pull Request (PR) is aimed at fixing some broken URLs across various documentation files in our repository.

Here's a brief overview of the changes:

- [x] Corrected the link to the Code of Conduct in the `CONTRIBUTING.md` file.
- [x] Updated the link to the Contributor Guidelines in the `README.md` file.
- [x] Fixed the URL pointing to the MIT License in the `README.md` file.

:bulb: These changes ensure that our community members and contributors can correctly navigate to important resources and information. 

Thank you for your time and consideration! :pray: